### PR TITLE
Handle parse("a")

### DIFF
--- a/parse-names.js
+++ b/parse-names.js
@@ -147,6 +147,7 @@ var NameParse = (function(){
 
 	// single letter, possibly followed by a period
 	NameParse.is_initial = function (word) {
+		if (!word) { return false; }
 		word = this.removeIgnoredChars(word);
 		return (word.length === 1);
 	};


### PR DESCRIPTION
`parse` will currently error for a single letter input, because `is_initial(word[0])` will return true, and then `parse` will call `is_initial(word[1])` when `word[1]` is undefined.