### PR TITLE
Use regular map keys

### DIFF
--- a/parse-names.js
+++ b/parse-names.js
@@ -80,11 +80,11 @@ var NameParse = (function(){
 	
 		// return the various parts in an array
 		return {
-			"salutation": salutation || "",
-			"firstName": firstName.trim(),
-			"initials": initials.trim(),
-			"lastName": lastName.trim(),
-			"suffix": suffix || ""
+			salutation: salutation || "",
+			firstName: firstName.trim(),
+			initials: initials.trim(),
+			lastName: lastName.trim(),
+			suffix: suffix || ""
 		};
 	};
 


### PR DESCRIPTION
Using the quotes with google's closure compiler in advanced mode will prevent renaming, which will break references to the renamed keys.

https://developers.google.com/closure/compiler/docs/limitations