### PR TITLE
Compound LN - one letter and capitalized -> initial

### DIFF
--- a/parse-names-test.html
+++ b/parse-names-test.html
@@ -93,6 +93,33 @@
 					"lastName": "Williams",
 					"suffix": ""
 				}
+			}, {
+				name: "Jack O'Neill",
+				result: {
+					"salutation": "",
+					"firstName": "Jack",
+					"initials": "",
+					"lastName": "O'Neill",
+					"suffix": ""
+				}
+			}, {
+				name: "Jack o Neill",
+				result: {
+					"salutation": "",
+					"firstName": "Jack",
+					"initials": "",
+					"lastName": "O Neill",
+					"suffix": ""
+				}
+			}, {
+				name: "Jack O Neill",
+				result: {
+					"salutation": "",
+					"firstName": "Jack",
+					"initials": "O",
+					"lastName": "Neill",
+					"suffix": ""
+				}
 			}];
 
 			test('Test names', function() {

--- a/parse-names.js
+++ b/parse-names.js
@@ -60,7 +60,10 @@ var NameParse = (function(){
 			// move on to parsing the last name if we find an indicator of a compound last name (Von, Van, etc)
 			// we do not check earlier to allow for rare cases where an indicator is actually the first name (like "Von Fabella")
 			if (this.is_compound_lastName(word)) {
-				break;
+			    if (!(this.is_initial(word) && word === word.toUpperCase())) {
+			        //If it's one letter and capitalized, consider it a middle initial
+			        break;
+			    }
 			}
 
 			if (this.is_initial(word)) {


### PR DESCRIPTION
With 'o' being a compound last name variable, it can create a problem if the person has a middle initial of 'O'.  This evaluates the compound variable - if it is one letter and it is capitalized, then consider it a middle initial instead of a compound last name.